### PR TITLE
FelixViewer updated

### DIFF
--- a/felix/FelixQuickViewer/ver3/BaseClass.cc
+++ b/felix/FelixQuickViewer/ver3/BaseClass.cc
@@ -106,7 +106,20 @@ bool BaseClass::ReadHistograms()
 	{
 	  string name_chip = "chip" + to_string( j ) ;
 
-	  // just in case
+	  ///////////////////////////////////////////
+	  // under test
+	  ///////////////////////////////////////////
+	  string name_hist_ch_adc_ampl = "hist_ch_adc_ampl_" + name_module + name_chip;
+	  try
+	    {
+	      hist_ch_adc_ampl_[i][j] = (TH3D*)f1_->Get( name_hist_ch_adc_ampl.c_str() );
+	    }
+	  catch( const std::runtime_error& error )
+	    {
+	      hist_ch_adc_ampl_[i][j] = new TH3D();
+	    }
+
+	  ///////////////////////////////////////////
 	  string name_hist_adc_ch = "hist_adc_ch_" + name_module + name_chip;
 	  try
 	    {
@@ -158,6 +171,18 @@ bool BaseClass::ReadHistograms()
 	    {
 	      hist_adc_[i][j] = new TH1D();
 	    }
+
+	  string name_hist_bco_diff = "hist_bco_diff_" + name_module + name_chip;
+	  try
+	    {
+	      hist_bco_diff_[i][j] = (TH1D*)f1_->Get( name_hist_bco_diff.c_str() );
+	    }
+	  catch( const std::runtime_error& error )
+	    {
+	      hist_bco_diff_[i][j] = new TH1D();
+	    }
+
+
 	}
     }
 

--- a/felix/FelixQuickViewer/ver3/BaseClass.hh
+++ b/felix/FelixQuickViewer/ver3/BaseClass.hh
@@ -47,15 +47,25 @@ protected:
   // variables for misc
   int width_ = 100;
   int canvas_counter = 0;
+  const int kLadder_colors[14]
+  = {
+    kBlack,      kRed,         kOrange + 1, kGreen + 2,
+    kTeal + 2,   kCyan + 2,    kAzure + 1,  kBlue + 2,
+    kViolet + 1, kMagenta + 1, kPink + 1,   kGray + 1,
+    kYellow + 2, kViolet + 5
+  };
   
   TFile* f1_;
 
   vector < string > print_buffer_;
+  TH3D* hist_ch_adc_ampl_[14][26]; // putting parameters into higher-dimension histograms is slightly faster
   TH2D* hist_adc_ch_[14][26];
   TH2D* hist_ampl_adc_[14][26];
   TH2D* hist_ch_ampl_[14][26];
   TH1D* hist_adc_[14][26];
   TH1D* hist_ch_[14][26];
+
+  TH1D* hist_bco_diff_[14][26];
 
   /////////////////////////////////////
   // protected member functions      //

--- a/felix/FelixQuickViewer/ver3/HistMaker.hh
+++ b/felix/FelixQuickViewer/ver3/HistMaker.hh
@@ -30,7 +30,7 @@ private:
   int chan_id_;
   int fem_id_;
   int bco_;
-  int bco_full_;
+  Long64_t bco_full_;
   int event_;
 
   // ROOT objects

--- a/felix/FelixQuickViewer/ver3/Homepage.py
+++ b/felix/FelixQuickViewer/ver3/Homepage.py
@@ -19,6 +19,7 @@ class Homepage() :
     def __init__( self, args ) :
         self.info = args
 
+        self.HOMEPAGE_ADDRESS = "https://sphenix-intra.sdcc.bnl.gov/WWW/subsystem/intt/"
         self.HOMEPAGE_ROOT_DIR = pathlib.Path( "/sphenix/WWW/subsystem/intt" )
         self.COMMISSIONING_DIR = pathlib.Path( self.HOMEPAGE_ROOT_DIR / "commissioning_plots" )
         self.YEAR_DIR = pathlib.Path( self.COMMISSIONING_DIR / str(self.info.year) )
@@ -120,6 +121,14 @@ class Homepage() :
         with open( str(self.index_html), mode='a' ) as file :
             file.write( "<h1>" + "Run " + str( int(self.info.run) ) + "</h1>\n" )
 
+            year_page = self.HOMEPAGE_ADDRESS + "/commissioning_plots/" + str( self.info.year ) + "/index.html"
+            file.write( "<a href=\"" + year_page + "\">" \
+                        + "Go back to " + str(self.info.year) + " run list"\
+                        + "</a>" )
+
+        # for table of contents
+        self.WriteToc()
+            
         for felix in range(0, 8 ):
             self.WriteFelixSection( felix )
             
@@ -145,6 +154,30 @@ class Homepage() :
             
         print( "  --->", self.index_html, "generated." )
 
+    def WriteToc( self ) :
+        with open( str(self.index_html), mode='a' ) as file :
+            felix_list = []
+            for felix in range(0, 8 ) :
+                server = "intt" + str(felix)
+                # check whether at least one plot from this server is in the plot list 
+                flag = True in [ server in str(val) for val in self.info.homepage_plots ]
+
+                # store the FELIX server used in this run
+                if flag : 
+                    felix_list.append( server )
+
+            # if the number of the servers in use is not so many, no toc is needed
+            if len( felix_list ) < 3 :
+                return None
+
+            # Write toc!
+            file.write( "<ul>\n" )
+            for server in felix_list :
+                file.write( "    <li><a href=\"#" + server + "\">" + server + "</a></li>\n" )
+
+            file.write( "</ul>\n\n" )
+                    
+        
     def WriteFelixSection( self, felix ) :
         with open( str(self.index_html), mode='a' ) as file :
             server = "intt" + str(felix)
@@ -190,7 +223,7 @@ class Homepage() :
 
             # after loop over all plots, all contents are in the variable. It the contents is not nohting, write it down
             if counter != 0 :
-                file.write( "<h2>" + server + "</h2>\n" )
+                file.write( "<h2 id=\"" + server+ "\">" + server + "</h2>\n" )
                 file.write( contents )
                 contents = ""
 

--- a/felix/FelixQuickViewer/ver3/Viewer.cc
+++ b/felix/FelixQuickViewer/ver3/Viewer.cc
@@ -67,6 +67,41 @@ void Viewer::InitLadderMap()
 }
 */
 
+unsigned int Viewer::GetMaxBinContent1D( TH1D* hists[kLadder_num_], int rank = 1, int ladder_min, int ladder_max )
+{
+  assert( r > 0 );
+  
+  vector < unsigned int > values;
+  for( int i=ladder_min; i<ladder_max; i++ ) // in y direction
+    {
+      for( int j=1; j<hists[i]->GetNbinsX()+1; j++ )
+	{
+	  values.push_back( hists[i]->GetBinContent( j ) );
+	  
+	}
+    }
+
+  int return_value = 0 ;
+  if( rank == 1 )
+    {
+      return_value = *max_element( values.begin(), values.end() );
+    }
+  else
+    {
+
+      assert( rank < values.size() );
+      sort( values.rbegin(), values.rend()  );
+      
+      for( int i=0; i<rank; i++ )
+	cout << i << "\t" << values[i] << endl;
+      
+      return_value = values[ rank ];
+    }
+
+  //return_value = *max_element( values.begin(), values.end() );
+  return return_value;
+}
+
 unsigned int Viewer::GetMaxBinContent( TH1D* hists[kLadder_num_][kChip_num_], int rank = 1, int ladder_min, int ladder_max, int chip_min, int chip_max )
 {
   assert( r > 0 );
@@ -486,12 +521,14 @@ int Viewer::Draw()
       else if( run_type_ == "cosmics" )
 	{
 	  this->Draw_HitDist();
+	  this->Draw_BcoDiff();
 	}
       else if( run_type_ == "beam" )
 	{
 	  this->Draw_Channel();
 	  this->Draw_AdcChannel();
 	  this->Draw_HitDist();
+	  this->Draw_BcoDiff();
 	}
     }
   else // for junk data
@@ -504,6 +541,7 @@ int Viewer::Draw()
       this->Draw_HitDist( kLadder_num_/2, kLadder_num_); //
       
     }
+  
   
   return 0;
 }
@@ -782,6 +820,78 @@ int Viewer::Draw_HitDist( int ladder_min, int ladder_max, int chip_min, int chip
     }
 
   string output = this->GetOutputPath( ladder_min, ladder_max, chip_min, chip_max, "hit_dist" );
+  c->Print( output.c_str() );
+  cout << output << endl << endl;
+  
+  return 0;
+}
+
+int Viewer::Draw_BcoDiff( int ladder_min, int ladder_max, int chip_min, int chip_max )
+{
+
+  TCanvas* c = new TCanvas( this->GetCanvasName().c_str(), this->GetCanvasTitle().c_str(), 2560, 1600 );
+
+  //////////////////////////////////////////////////
+  // Make histogram ladder by ladder since it's made for every ladder and chip
+  //////////////////////////////////////////////////
+
+  // make the instance and init with the hist for chip0
+  TH1D* hist_bco_diff_ladder[ kLadder_num_ ];
+  for( int i=0; i<kLadder_num_; i++ )
+    hist_bco_diff_ladder[i] = (TH1D*)hist_bco_diff_[i][0]->Clone();
+
+  // Add data 
+  for( int i=0; i<kLadder_num_; i++ )
+    for( int j=1; j<kChip_num_; j++ )
+      {
+	hist_bco_diff_ladder[i]->Add( hist_bco_diff_[i][j] );
+      }
+  
+  //auto y_max = GetMaxBinContentRatio( hist_bco_diff_ladder_, 0.01, ladder_min, ladder_max, chip_min, chip_max ); // Bins on the top 1% are ignored
+  auto y_max = GetMaxBinContent1D( hist_bco_diff_ladder, 1 );
+
+  if( run_type_ == "calib" || run_type_ == "calibration" )
+    y_max = 500;
+  else if( y_max < 0.9 )
+    y_max = 1;
+  
+  // this->CanvasPreparation( c,
+  // 			   0, 127, 0.9, y_max,
+  // 			   0, 2, 0, 1,
+  // 			   hist_bco_diff_[0][0]->GetName() );
+
+  c->Divide( 1, 2 );
+
+  ////////////////////////////////////////////////////////////////////////
+  // Draw!                                                              //
+  ////////////////////////////////////////////////////////////////////////
+  TLegend* leg = new TLegend( 0.91, 0.1, 0.99, 0.9 );
+  
+  c->cd( 2 );
+  for( int i=ladder_min; i<ladder_max; i++ ) // in y direction
+    {
+
+      hist_bco_diff_ladder[i]->SetLineColor( kLadder_colors[i] );
+      hist_bco_diff_ladder[i]->SetLineWidth( 3 );
+      hist_bco_diff_ladder[i]->GetYaxis()->SetRangeUser( 0.9, y_max );
+      string option = "HIST same";
+      if( i == 0 || i == 7 )
+	option = "HIST";
+      
+      hist_bco_diff_ladder[i]->Draw( option.c_str() );
+      this->SetStyle();
+      gPad->SetLogy( true );
+
+      leg->AddEntry( hist_bco_diff_ladder[i], ( "FELIX CH" + to_string(i) ).c_str() );
+      if( i == 6 || i == ladder_max-1 )
+	{
+	  leg->Draw();
+	  leg = new TLegend( 0.91, 0.1, 0.99, 0.9 );
+	  c->cd( 1 );
+	}
+    }
+
+  string output = this->GetOutputPath( ladder_min, ladder_max, chip_min, chip_max, "bco_diff" );
   c->Print( output.c_str() );
   cout << output << endl << endl;
   

--- a/felix/FelixQuickViewer/ver3/Viewer.hh
+++ b/felix/FelixQuickViewer/ver3/Viewer.hh
@@ -72,6 +72,7 @@ private:
   TCanvas* c_adc_;
   TCanvas* c_adc_ch_;
 
+  unsigned int GetMaxBinContent1D( TH1D* hists[kLadder_num_], int rank, int ladder_min=0, int ladder_max=kLadder_num_ );
   unsigned int GetMaxBinContent( TH1D* hists[kLadder_num_][kChip_num_], int rank, int ladder_min=0, int ladder_max=kLadder_num_, int chip_min=0, int chip_max=kChip_num_);
   unsigned int GetMaxBinContentRatio( TH1D* hists[kLadder_num_][kChip_num_], double remove_top, int ladder_min=0, int ladder_max=kLadder_num_, int chip_min=0, int chip_max=kChip_num_); // Bins at top x% are ignored
   string GetOutputPath( int ladder_min=0, int ladder_max=kLadder_num_, int chip_min=0, int chip_max=kChip_num_, string keyword="default" );
@@ -106,6 +107,7 @@ public:
   int Draw_HitDist( int ladder_min=0, int ladder_max=kLadder_num_, int chip_min=0, int chip_max=kChip_num_);
   int Draw_AmplAdc( int ladder_min=0, int ladder_max=kLadder_num_, int chip_min=0, int chip_max=kChip_num_);
   int Draw_ChAmpl( int ladder_min=0, int ladder_max=kLadder_num_, int chip_min=0, int chip_max=kChip_num_);
+  int Draw_BcoDiff( int ladder_min=0, int ladder_max=kLadder_num_, int chip_min=0, int chip_max=kChip_num_);
   
   TCanvas* GetCanvasCh(){ return (TCanvas*)(c_ch_->Clone()); }
   


### PR DESCRIPTION
- 3D hists for ch vs ADC vs ampl were introduced. 3D hists are filled with data from ROOT file, and 2D and 1D hists are generated by projecting the 3D. It slightly sppeds up the process (not too much surprisingly).
- Hists of the lower 7 bits of BCO full - FPHX BCO were added. A switch to enable/disable these hists is needed depending on the run type to save processing time.
- Homepage processes were improved. Table of Contents is written in the run pages if more than 4 FELIX servers were used in the run.